### PR TITLE
Fix memory list filter

### DIFF
--- a/backend/services/memory_query/service.py
+++ b/backend/services/memory_query/service.py
@@ -78,8 +78,8 @@ def answer_query(db: Session, query: str, user_id: str, source_type: str = None,
         context_blocks.append(f"Title: {title}\nSummary: {summary}\nContent: {content}")
     memory_context = "\n\n".join(context_blocks)
 
-    # Get user’s full memory list
-    full_memory_list = list_user_memories(db, user_id=user_id, filter_by={"title": "LLM"})
+    # Get the user's full memory list to provide additional context
+    full_memory_list = list_user_memories(db, user_id=user_id)
 
     messages = [
         {"role": "system", "content": SYSTEM_PROMPT},


### PR DESCRIPTION
## Summary
- remove leftover "LLM" title filter when building memory list context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fce24683c832fb9387390f59858c6